### PR TITLE
Bugfix/liq to consider deposit subacc

### DIFF
--- a/src/bots/liquidator.ts
+++ b/src/bots/liquidator.ts
@@ -1630,6 +1630,16 @@ export class LiquidatorBot implements Bot {
 			return;
 		}
 
+		const subAccountToLiqDep = this.getSubAccountIdToLiquidateSpot(
+			depositMarketIndextoLiq
+		);
+		if (subAccountToLiqDep === undefined) {
+			logger.info(
+				`skipping liquidateSpot call for ${user.userAccountPublicKey.toBase58()} because the deposit market it not in subaccounts`
+			);
+			return;
+		}
+
 		const start = Date.now();
 		this.driftClient
 			.liquidateSpot(


### PR DESCRIPTION
The liquidator was only checking that it had a subaccount for the borrow to be liquidated, but not that it was also configured for the deposit it would try to use.