### PR TITLE
deps(sdk): bump @drift-labs/sdk to 2.163.0-beta.13

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 	"dependencies": {
 		"@drift-labs/common": "patch:@drift-labs/common@npm%3A1.0.20#~/.yarn/patches/@drift-labs-common-npm-1.0.20-cf92dd0082.patch",
 		"@drift-labs/jit-proxy": "0.21.171",
-		"@drift-labs/sdk": "2.163.0-beta.12",
+		"@drift-labs/sdk": "2.163.0-beta.13",
 		"@opentelemetry/api": "1.7.0",
 		"@opentelemetry/auto-instrumentations-node": "^0.62.1",
 		"@opentelemetry/exporter-prometheus": "0.31.0",
@@ -55,7 +55,7 @@
 		"simple-swizzle": "0.2.2",
 		"is-arrayish": "0.3.2",
 		"log-symbols": "4.1.0",
-		"@drift-labs/sdk": "2.163.0-beta.12"
+		"@drift-labs/sdk": "2.163.0-beta.13"
 	},
 	"devDependencies": {
 		"@types/chai": "4.3.11",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,6 +5,46 @@ __metadata:
   version: 8
   cacheKey: 10c0
 
+"@anchor-lang/borsh@npm:^1.0.1":
+  version: 1.0.2
+  resolution: "@anchor-lang/borsh@npm:1.0.2"
+  dependencies:
+    bn.js: "npm:^5.1.2"
+    buffer-layout: "npm:^1.2.0"
+  peerDependencies:
+    "@solana/web3.js": ^1.69.0
+  checksum: 10c0/39280bfb9141db5220f69ddea9567d52f654ef24ba9819002722af97310bead4da6214fd7fe04bab0f1ff6ceb887b4009e803415ce77f08094b253c416f2b4cc
+  languageName: node
+  linkType: hard
+
+"@anchor-lang/core@npm:1.0.1, @coral-xyz/anchor@npm:@anchor-lang/core@1.0.1":
+  version: 1.0.1
+  resolution: "@anchor-lang/core@npm:1.0.1"
+  dependencies:
+    "@anchor-lang/borsh": "npm:^1.0.1"
+    "@anchor-lang/errors": "npm:^1.0.1"
+    "@noble/hashes": "npm:^1.3.1"
+    "@solana/web3.js": "npm:^1.69.0"
+    bn.js: "npm:^5.1.2"
+    bs58: "npm:^4.0.1"
+    buffer-layout: "npm:^1.2.2"
+    camelcase: "npm:^6.3.0"
+    cross-fetch: "npm:^3.1.5"
+    eventemitter3: "npm:^4.0.7"
+    pako: "npm:^2.0.3"
+    superstruct: "npm:^0.15.4"
+    toml: "npm:^3.0.0"
+  checksum: 10c0/1f2311cf5ce726f5bdce606f81251fd8175002db606ae924e313ab27620dac1296e38e4d2e5a9fca5d2dd668f145df671212f879fe24ecca24fc5577a796faf3
+  languageName: node
+  linkType: hard
+
+"@anchor-lang/errors@npm:^1.0.1":
+  version: 1.0.2
+  resolution: "@anchor-lang/errors@npm:1.0.2"
+  checksum: 10c0/020b780f3ff7b84e6ac7b63c77ca91a1c2ab5dd202f792c4f171e4eb90cd88cc987cc7f27a8cfe223d366bda58610f0656d370947073d46b5711d198bb57087c
+  languageName: node
+  linkType: hard
+
 "@babel/code-frame@npm:7.12.11":
   version: 7.12.11
   resolution: "@babel/code-frame@npm:7.12.11"
@@ -76,34 +116,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@coral-xyz/anchor-errors@npm:^0.31.1":
-  version: 0.31.1
-  resolution: "@coral-xyz/anchor-errors@npm:0.31.1"
-  checksum: 10c0/d359d6244a89bcfb606e6d31d545c3be8e32dccd47b78dac6ec0091a51b2eb6c78aad9601f39db2659d8e66db8fffc36477247d58d570bc9d866e7ec3e40b5b2
-  languageName: node
-  linkType: hard
-
-"@coral-xyz/anchor@npm:@coral-xyz/anchor@0.32.1":
-  version: 0.32.1
-  resolution: "@coral-xyz/anchor@npm:0.32.1"
-  dependencies:
-    "@coral-xyz/anchor-errors": "npm:^0.31.1"
-    "@coral-xyz/borsh": "npm:^0.31.1"
-    "@noble/hashes": "npm:^1.3.1"
-    "@solana/web3.js": "npm:^1.69.0"
-    bn.js: "npm:^5.1.2"
-    bs58: "npm:^4.0.1"
-    buffer-layout: "npm:^1.2.2"
-    camelcase: "npm:^6.3.0"
-    cross-fetch: "npm:^3.1.5"
-    eventemitter3: "npm:^4.0.7"
-    pako: "npm:^2.0.3"
-    superstruct: "npm:^0.15.4"
-    toml: "npm:^3.0.0"
-  checksum: 10c0/669b6f54efb0a5a96dad9e055d30b3b803f691b1b058379efefb87c11f97a9d369d513b2f200082c0b55b4cb31540dc5404e244c6f23f0a14b6d2ad2e18f08b7
-  languageName: node
-  linkType: hard
-
 "@coral-xyz/borsh@npm:^0.29.0":
   version: 0.29.0
   resolution: "@coral-xyz/borsh@npm:0.29.0"
@@ -113,18 +125,6 @@ __metadata:
   peerDependencies:
     "@solana/web3.js": ^1.68.0
   checksum: 10c0/25afec48714d9f0c95a02d04215803181f7da0aad85fdd1b076d9f37ef54586342e01e24fc1b2128aba0b5155e970afd6a2c6f8b0343699d8733c0703655ce39
-  languageName: node
-  linkType: hard
-
-"@coral-xyz/borsh@npm:^0.31.1":
-  version: 0.31.1
-  resolution: "@coral-xyz/borsh@npm:0.31.1"
-  dependencies:
-    bn.js: "npm:^5.1.2"
-    buffer-layout: "npm:^1.2.0"
-  peerDependencies:
-    "@solana/web3.js": ^1.69.0
-  checksum: 10c0/3d6d40a1476df5eb0635d8687a640de89fd7e7ffd135f733907f13ff2569a2a07f65f64768d632fb45ed55006d9c9ee94e40fd775813a9cf1211fefa567f98dd
   languageName: node
   linkType: hard
 
@@ -221,7 +221,7 @@ __metadata:
   dependencies:
     "@drift-labs/common": "patch:@drift-labs/common@npm%3A1.0.20#~/.yarn/patches/@drift-labs-common-npm-1.0.20-cf92dd0082.patch"
     "@drift-labs/jit-proxy": "npm:0.21.171"
-    "@drift-labs/sdk": "npm:2.163.0-beta.12"
+    "@drift-labs/sdk": "npm:2.163.0-beta.13"
     "@opentelemetry/api": "npm:1.7.0"
     "@opentelemetry/auto-instrumentations-node": "npm:^0.62.1"
     "@opentelemetry/exporter-prometheus": "npm:0.31.0"
@@ -269,11 +269,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@drift-labs/sdk@npm:2.163.0-beta.12":
-  version: 2.163.0-beta.12
-  resolution: "@drift-labs/sdk@npm:2.163.0-beta.12"
+"@drift-labs/sdk@npm:2.163.0-beta.13":
+  version: 2.163.0-beta.13
+  resolution: "@drift-labs/sdk@npm:2.163.0-beta.13"
   dependencies:
-    "@coral-xyz/anchor": "npm:@coral-xyz/anchor@0.32.1"
+    "@anchor-lang/core": "npm:1.0.1"
+    "@coral-xyz/anchor": "npm:@anchor-lang/core@1.0.1"
     "@coral-xyz/anchor-29": "npm:@coral-xyz/anchor@0.29.0"
     "@ellipsis-labs/phoenix-sdk": "npm:1.4.5"
     "@msgpack/msgpack": "npm:^3.1.2"
@@ -301,7 +302,7 @@ __metadata:
   dependenciesMeta:
     helius-laserstream:
       optional: true
-  checksum: 10c0/6383965cdfa5c8eb08b7320fa21660d8880a794f005a3bf69af693dea39fb447112d044248f306d214b7c479cebff5b38c2365b3c7bf6c0b58693c5c7afaff5f
+  checksum: 10c0/309498b78c6b5d9d7255d572da834a485fa69446a4fa7cfe7d588c1640a3ed670694d9f20443ef50bf63dd000702e7741d6e0fb8fb1383fa2e781bb011c09973
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Problem

Devnet `liquidator-bot` is logging:

```
[info]: Added subaccount 2 to driftClient since it was missing (subscribed: true)
PollingUserStatsAccountSubscriber.fetch() UserStatsAccount does not exist: Account does not exist 42vnCCW1kV4M53xz8nwNUJ6pED6ewpjgiY6cw1WX4Awo
Bulk account load: error in account callback
```

Most likely a runtime chain-state lookup (the UserStats account genuinely doesn't exist on devnet for that subaccount), but worth a defensive SDK bump in case an upstream fix landed.

## Change

- `@drift-labs/sdk`: `2.163.0-beta.12` -> `2.163.0-beta.13` (current `latest` dist-tag)
- `yarn.lock` regenerated; the existing `@drift-labs/common@1.0.20` patch still applies cleanly
- Build, lint, prettier, and tests all pass

Bumping from beta.12 -> beta.13 also swaps `@coral-xyz/anchor` for the newer `@anchor-lang/*` packages upstream — picked up automatically.

## Bundler audit (defensive)

A sibling repo just landed a fix because `@drift-labs/sdk` now publishes both `main = lib/node/index.js` and `module = lib/browser/index.js`, and bundlers with `mainFields` placing `module` ahead of `main` were pulling the browser entry (throws "AnchorProvider not supported in browser") into node-targeted bundles.

This repo's `esbuild.config.js` does not override `mainFields` and uses `platform: 'node'`, so esbuild's default resolution (`main` before `module`) already picks the correct node entry. Spot-checked the rebuilt `lib/index.js` — pulls in the real `AnchorProvider` class, no browser-throw stub. No change required.

## Not claimed

This does not necessarily fix the `UserStatsAccount does not exist` runtime error — that is most likely chain state and needs to be investigated separately after the deploy lands and we observe the bot.

## Test plan

- [x] `yarn install` clean
- [x] `yarn build` succeeds
- [x] `yarn lint` clean
- [x] `yarn prettify` clean
- [x] `yarn test` passes
- [ ] Observe `liquidator-bot` logs after non-prod rollout