### PR TITLE
fix(config): source lazerToken from PYTH_LAZER_TOKEN env

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -243,6 +243,7 @@ const defaultConfig: Partial<Config> = {
 		hermesEndpoint: process.env.HERMES_ENDPOINT,
 		wsEndpoint: process.env.WS_ENDPOINT,
 		heliusEndpoint: process.env.HELIUS_ENDPOINT,
+		lazerToken: process.env.PYTH_LAZER_TOKEN,
 		additionalSendTxEndpoints: [],
 		txConfirmationEndpoint: process.env.TX_CONFIRMATION_ENDPOINT,
 		priorityFeeMethod: process.env.PRIORITY_FEE_METHOD ?? 'solana',


### PR DESCRIPTION
globalConfig.lazerToken was sourced only from configMap, where kubelet doesn't substitute `$()` placeholders inside file content — so bots load the literal string and crash. Add `process.env.PYTH_LAZER_TOKEN` fallback in defaults so deployment can wire the secret via `secretKeyRef` env. Pairs with infrastructure-v3 PR removing configMap placeholders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)