### PR TITLE
log: surface simError/slot/logs on pyth lazer sim failure

### DIFF
--- a/src/bots/pythLazerCranker.ts
+++ b/src/bots/pythLazerCranker.ts
@@ -315,8 +315,21 @@ export class PythLazerCrankerBot implements Bot {
 				});
 				if (simResult.simError) {
 					logger.error(
-						`Error simulating pyth lazer oracles for ${feedIds}: ${simResult.simTxLogs}`
+						`Error simulating pyth lazer oracles for [${feedIds.join(
+							','
+						)}] at slot ${simResult.simSlot}: ${JSON.stringify(
+							simResult.simError
+						)}`
 					);
+					if (simResult.simTxLogs?.length) {
+						for (const line of simResult.simTxLogs) {
+							logger.error(`  sim log: ${line}`);
+						}
+					} else {
+						logger.error(
+							`  no program logs returned — tx likely failed account validation or ed25519 precompile (cuEstimate=${simResult.cuEstimate})`
+						);
+					}
 					continue;
 				}
 				const startTime = Date.now();


### PR DESCRIPTION
## Why

On devnet the pyth-lazer-cranker bot is logging a tight loop of:

```
error: Error simulating pyth lazer oracles for 1,6,8: null
```

The trailing `null` is `simResult.simTxLogs` rendered through a template literal — when the RPC returns no program logs (typical when a tx fails account validation or the ed25519 precompile before any program instruction runs), the message gives the operator nothing actionable. `simError` itself is never logged.

## What

In `PythLazerCrankerBot.runCrankLoop`'s sim-error branch:

- Log the structured `simError` via `JSON.stringify` (so e.g. `{"InstructionError":[1,{"Custom":6020}]}` or `"AccountNotFound"` is visible).
- Log the `simSlot` so the failure can be correlated against on-chain state at that slot.
- If `simTxLogs` is non-empty, emit each line on its own log line (legible).
- If `simTxLogs` is empty, emit a hint pointing at the two most-common pre-execution failure modes (account validation, ed25519 precompile) and include `cuEstimate` for context.

No control-flow changes — the `continue` still runs on `simError`.

## Test plan

- [ ] Build + push `keeper-bots-v2:latest-master-amd64`
- [ ] Rollout-restart `pyth-lazer-cranker-bot` in `master` namespace on `drift-non-prod`
- [ ] Confirm logs now include `simError={...}` and either each program log line or the "no program logs returned" hint