### PR TITLE
fix(experimental-bots/entrypoint): honor globalConfig.initUser

### DIFF
--- a/src/experimental-bots/entrypoint.ts
+++ b/src/experimental-bots/entrypoint.ts
@@ -245,6 +245,23 @@ const runBot = async () => {
 	await driftClient.subscribe();
 	await driftClient.fetchAllLookupTableAccounts();
 
+	// Mirrors checkUserExists in src/index.ts: every bot wired into this
+	// entrypoint constructs a UserMap or accesses driftClient.getUser() and
+	// will throw if the keeper has no User PDA on chain. Honor the
+	// globalConfig.initUser flag the same way the legacy entrypoint does.
+	if (!(await driftClient.getUser().exists())) {
+		logger.error(
+			`User for ${wallet.publicKey} does not exist (subAccountId: ${driftClient.activeSubAccountId})`
+		);
+		if (config.global.initUser) {
+			logger.info(`Creating User for ${wallet.publicKey}`);
+			const [txSig] = await driftClient.initializeUserAccount();
+			logger.info(`Initialized user account in transaction: ${txSig}`);
+		} else {
+			throw new Error('Set initUser: true in config to initialize a User');
+		}
+	}
+
 	const slotSubscriber = new SlotSubscriber(connection, {
 		resubTimeoutMs: 10_000,
 	});


### PR DESCRIPTION
## Problem

`order-filler-multithreaded-bot` (and every other bot wired through `src/experimental-bots/entrypoint.ts`) crashes at startup on a fresh keeper keypair with:

```
Error: User account not found for subaccount: 0
    at new FillerMultithreaded (fillerMultithreaded.ts:318)
```

The infra config already sets `initUser: true` for these bots (drift-labs/infrastructure-v3@79857c61 flipped it across the devnet stage), but the flag is silently ignored — the experimental entrypoint constructs `DriftClient` and goes straight to bot construction.

## Cause

The legacy `src/index.ts` honors the flag via `checkUserExists` (lines 1075-1093, called at line 901). The experimental entrypoint at `src/experimental-bots/entrypoint.ts` never got the equivalent: there is no `getUser().exists()` check, no `initializeUserAccount()` call. Result is that bots whose constructors require a User PDA fail with a less-actionable error from their own code path.

## Fix

Inline the same check after `driftClient.subscribe()` + `fetchAllLookupTableAccounts()`, before the slot subscriber:

```ts
if (!(await driftClient.getUser().exists())) {
    logger.error(
        `User for ${wallet.publicKey} does not exist (subAccountId: ${driftClient.activeSubAccountId})`
    );
    if (config.global.initUser) {
        logger.info(`Creating User for ${wallet.publicKey}`);
        const [txSig] = await driftClient.initializeUserAccount();
        logger.info(`Initialized user account in transaction: ${txSig}`);
    } else {
        throw new Error('Set initUser: true in config to initialize a User');
    }
}
```

Matches the legacy `checkUserExists` body verbatim (same log strings, same control flow). The only difference is the error message — the experimental entrypoint has no `--init-user` CLI flag (it's YAML-driven), so the message points at the config field.

Inline rather than extracted because the legacy helper isn't exported. Happy to lift it to `utils.ts` instead if that's preferred for both entrypoints to share.

## Test plan

- [ ] Build + push `keeper-bots-v2:latest-master-amd64`
- [ ] Rollout-restart `order-filler-multithreaded-bot` in `master` namespace on `drift-non-prod`
- [ ] Confirm startup logs include `Creating User for <pubkey>` followed by `Initialized user account in transaction: <sig>`
- [ ] Confirm the bot stays Running and the `FillerMultithreaded` constructor no longer throws
- [ ] Spot-check that other experimental bots whose configs already have `initUser: true` (mmOracleCranker, swiftPlacer, etc.) also pick up the new check without regressing