### PR TITLE
fix(experimental-bots/entrypoint): use hasUser() instead of getUser().exists()

### DIFF
--- a/src/experimental-bots/entrypoint.ts
+++ b/src/experimental-bots/entrypoint.ts
@@ -245,17 +245,15 @@ const runBot = async () => {
 	await driftClient.subscribe();
 	await driftClient.fetchAllLookupTableAccounts();
 
-	// Mirrors checkUserExists in src/index.ts: every bot wired into this
-	// entrypoint constructs a UserMap or accesses driftClient.getUser() and
-	// will throw if the keeper has no User PDA on chain. Honor the
-	// globalConfig.initUser flag the same way the legacy entrypoint does.
-	if (!(await driftClient.getUser().exists())) {
+	if (!driftClient.hasUser()) {
 		logger.error(
 			`User for ${wallet.publicKey} does not exist (subAccountId: ${driftClient.activeSubAccountId})`
 		);
 		if (config.global.initUser) {
 			logger.info(`Creating User for ${wallet.publicKey}`);
-			const [txSig] = await driftClient.initializeUserAccount();
+			const [txSig] = await driftClient.initializeUserAccount(
+				driftClient.activeSubAccountId
+			);
 			logger.info(`Initialized user account in transaction: ${txSig}`);
 		} else {
 			throw new Error('Set initUser: true in config to initialize a User');


### PR DESCRIPTION
## Problem

Follow-up to #608. With that PR merged, `order-filler-multithreaded-bot` got past the `FillerMultithreaded` constructor error and is now crashing on the user-existence check itself:

```
Error: VelocityClient has no user for user id 0_FetTyW8xAYfd33x4GMHoE7hTuEdWLj1fNnhJuyVMUGGa
    at VelocityClient.getUser (velocityClient.ts:2279)
    at runBot (experimental-bots/entrypoint.ts)
```

## Cause

The velocity SDK's `getUser()` (velocityClient.ts:2273-2282) throws when the local user map has no entry for the active subaccount/authority pair. `getUser().exists()` therefore can't be used as a presence check — the throw happens before `.exists()` runs.

The map is populated by `addAndSubscribeToUsers()` during `driftClient.subscribe()`, but `addUser` only sets the entry when the User PDA actually exists on chain (returns `false` and skips otherwise). So:
- User PDA exists on chain → `hasUser()` returns `true`
- User PDA missing → `hasUser()` returns `false`, `getUser()` throws

`hasUser()` (velocityClient.ts:2284-2290) is the non-throwing equivalent.

This differs from the legacy `@drift-labs/sdk` where `getUser()` was lenient, which is why the legacy `checkUserExists` helper (src/index.ts:1075) could use `getUser().exists()` safely.

## Fix

Swap the check to `driftClient.hasUser()`. Also pass `driftClient.activeSubAccountId` to `initializeUserAccount()` explicitly — the SDK default is 0, which silently diverges from operator config when `globalConfig.subaccounts[0]` is non-zero. `initializeUserAccount` calls `addUser()` internally (velocityClient.ts:1073), so subsequent bot constructors that call `getUser()` succeed after init without further wiring.

## Test plan

- [ ] Build + push `keeper-bots-v2:latest-master-amd64`
- [ ] Rollout-restart `order-filler-multithreaded-bot` in `master` namespace on `drift-non-prod`
- [ ] Confirm the bot reaches `Creating User for <pubkey>` → `Initialized user account in transaction: <sig>` and stays Running