### PR TITLE
fix(filler): skip unknown market indexes instead of crashing

### DIFF
--- a/src/experimental-bots/filler-common/dlobBuilder.ts
+++ b/src/experimental-bots/filler-common/dlobBuilder.ts
@@ -40,7 +40,11 @@ import {
 	SerializedNodeToFill,
 	NodeToFillWithContext,
 } from './types';
-import { getDriftClientFromArgs, serializeNodeToFill } from './utils';
+import {
+	getDriftClientFromArgs,
+	getValidMarketIndexes,
+	serializeNodeToFill,
+} from './utils';
 import { sleepMs } from '../../utils';
 import { LRUCache } from 'lru-cache';
 import { sha256 } from '@noble/hashes/sha256';
@@ -446,6 +450,7 @@ const main = async () => {
 	if (marketTypeStr !== 'perp' && marketTypeStr !== 'spot') {
 		throw new Error("market-type must be either 'perp' or 'spot'");
 	}
+	marketIndexes = getValidMarketIndexes(marketIndexes, marketTypeStr, driftEnv);
 
 	let marketType: MarketType;
 	switch (marketTypeStr) {

--- a/src/experimental-bots/filler-common/orderSubscriberFiltered.ts
+++ b/src/experimental-bots/filler-common/orderSubscriberFiltered.ts
@@ -15,7 +15,7 @@ import { Connection, PublicKey, RpcResponseAndContext } from '@solana/web3.js';
 import dotenv from 'dotenv';
 import { logger } from '../../logger';
 import parseArgs from 'minimist';
-import { getDriftClientFromArgs } from './utils';
+import { getDriftClientFromArgs, getValidMarketIndexes } from './utils';
 
 const logPrefix = '[OrderSubscriberFiltered]';
 
@@ -242,11 +242,12 @@ const main = async () => {
 	const args = parseArgs(process.argv.slice(2));
 	const driftEnv = args['drift-env'] ?? 'devnet';
 	const marketIndexesStr = String(args['market-indexes']);
-	const marketIndexes = marketIndexesStr.split(',').map(Number);
+	let marketIndexes = marketIndexesStr.split(',').map(Number);
 	const marketTypeStr = args['market-type'] as string;
 	if (marketTypeStr !== 'perp' && marketTypeStr !== 'spot') {
 		throw new Error("market-type must be either 'perp' or 'spot'");
 	}
+	marketIndexes = getValidMarketIndexes(marketIndexes, marketTypeStr, driftEnv);
 
 	let marketType: MarketType;
 	switch (marketTypeStr) {

--- a/src/experimental-bots/filler-common/utils.ts
+++ b/src/experimental-bots/filler-common/utils.ts
@@ -322,6 +322,33 @@ export const getOracleInfoForMarket = (
 	}
 };
 
+/**
+ * Drops market indexes that have no entry in the SDK config for this env, logging
+ * a warning instead of letting a later `undefined` oracle/market deref crash the
+ * worker. Keeps the bot running on the markets it does know about.
+ */
+export const getValidMarketIndexes = (
+	marketIndexes: number[],
+	marketTypeStr: 'spot' | 'perp',
+	env: DriftEnv
+): number[] => {
+	const sdkConfig = initialize({ env });
+	const configured: Array<PerpMarketConfig | SpotMarketConfig> =
+		marketTypeStr === 'perp' ? sdkConfig.PERP_MARKETS : sdkConfig.SPOT_MARKETS;
+	const known = new Set(configured.map((m) => m.marketIndex));
+	const missing = marketIndexes.filter((i) => !known.has(i));
+	if (missing.length > 0) {
+		logger.warn(
+			`No ${marketTypeStr} market config for index(es) [${missing.join(
+				', '
+			)}] on env '${env}'; skipping them. Known indexes: [${Array.from(
+				known
+			).join(', ')}]`
+		);
+	}
+	return marketIndexes.filter((i) => known.has(i));
+};
+
 export const getDriftClientFromArgs = ({
 	connection,
 	wallet,


### PR DESCRIPTION
## Why
The `order-filler-multithreaded` pod was in `CrashLoopBackOff` on devnet. Its config lists perp `marketIndexes: [0, 1]`, but the SDK's `DevnetPerpMarkets` only defines market 0. `getOracleInfoForMarket` did `PERP_MARKETS.find(... === 1)` → `undefined`, then derefed `undefined.oracle`, killing both the `dlobBuilder` and `orderSubscriber` worker processes on startup.

A single misconfigured/not-yet-listed market shouldn't take down filling for every other market.

## Approach
Filter unknown indexes once at parse time in each worker, before they reach `getDriftClientFromArgs` *and* the `DLOBBuilder`/`OrderSubscriberFiltered` constructors. Guarding only the oracle lookup wouldn't help — the same index later hits `getPerpMarketAccount(idx)` in `getdNodesToFill`, which throws `PerpMarket not found`. Filtering at the source fixes the whole chain without touching any existing function signature.

New `getValidMarketIndexes` helper drops indexes absent from the SDK config and `logger.warn`s them; the bot keeps running on the markets it knows.

## Notes
- This stops the crash; it does not list BTC-PERP. The proper fix for devnet market 1 is adding it to the SDK's `DevnetPerpMarkets` — tracked separately.