### PR TITLE
chore: rename drift-labs GitHub URLs to velocity-exchange

### DIFF
--- a/.github/workflows/velocity-publish.yml
+++ b/.github/workflows/velocity-publish.yml
@@ -2,7 +2,7 @@
 # the tagged commit and pushes keeper-bots-v2:vX.Y.Z to Velocity ECR. Tags
 # there are IMMUTABLE: a published version can never be overwritten —
 # re-releasing means a new tag. Deploying a version is a separate PR in
-# drift-labs/infrastructure-v3 bumping the gitops image pin.
+# velocity-exchange/infrastructure-v3 bumping the gitops image pin.
 #
 # Every version lands in non-prod ECR; the prod-copy steps below are
 # commented out until the prod account exists.

--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ The jit maker bot supplies liquidity to the protocol by participating in jit acu
 
 Read the docs on jit auctions: https://docs.drift.trade/just-in-time-jit-auctions
 
-Read the docs on the jit proxy client: https://github.com/drift-labs/jit-proxy/blob/master/ts/sdk/Readme.md
+Read the docs on the jit proxy client: https://github.com/velocity-exchange/jit-proxy/blob/master/ts/sdk/Readme.md
 
 Be aware that running a jit maker means taking on positional risk, so be sure to manage your risk properly!
 

--- a/quickstart.md
+++ b/quickstart.md
@@ -5,7 +5,7 @@ Drift Protocol Jit Market Making, offer fee rebates for providing liquidity.
 1. create and fund an account on drift protocol
 
 - can experiment using devnet, for mainnet make sure you understand the risks
-- see [keeper-bots-v2 readme](https://github.com/drift-labs/keeper-bots-v2#initialize-user)
+- see [keeper-bots-v2 readme](https://github.com/velocity-exchange/keeper-bots-v2#initialize-user)
 - or see https://drift-labs.github.io/v2-teacher/#introduction
 
 2. get a private RPC endpoint


### PR DESCRIPTION
Part of renaming the GitHub org drift-labs -> velocity-exchange.

**DRAFT — do not merge until the velocity-exchange org (and, where applicable, the @velocity-exchange npm scope) exists; old URLs currently redirect.**

## URL forms changed

- `@drift-labs/jit-proxy` npm scope → `@velocity-exchange/jit-proxy` (package.json dep, imports in src/bots/jitMaker.ts, src/bots/uncrossArbBot.ts, src/index.ts, yarn.lock)
- `@drift-labs/sdk` npm scope references → `@velocity-exchange/sdk` (.github/workflows/deploy-on-sdk-update.yml, DockerfileLinked, yarn.lock alias key, package.json resolution alias removed as now redundant)
- `github.com/drift-labs/jit-proxy` → `github.com/velocity-exchange/jit-proxy` (README.md)
- `github.com/drift-labs/keeper-bots-v2` → `github.com/velocity-exchange/keeper-bots-v2` (quickstart.md self-reference)
- `drift-labs/infrastructure-v3` → `velocity-exchange/infrastructure-v3` (.github/workflows/velocity-publish.yml comment)
- `drift-labs/sdk` grep patterns → `velocity-exchange/sdk` (.husky/post-merge, .husky/pre-commit)

Total files changed: 12

## Skipped (upstream-Drift historical refs)

- quickstart.md:9: `https://drift-labs.github.io/v2-teacher/#introduction` — external Drift Protocol documentation site linked as a resource for the original Drift project; not this repo's own asset
- src/experimental-bots/swift/makerExample.ts:75: `https://github.com/drift-labs/protocol-v2/...` — code comment linking to upstream Drift SDK source for developer reference
- src/experimental-bots/swift/placerExample.ts:112: same as above

## Warning: @velocity-exchange npm scope packages

The following packages must be published under `@velocity-exchange` on npm before builds will succeed (the old `@drift-labs` scope names will no longer resolve once the redirect is removed):

- `@velocity-exchange/jit-proxy` — currently published as `@drift-labs/jit-proxy`; builds will break until this is republished under the new scope